### PR TITLE
Handle infinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.2.1] - 2020-06-24
+
+### Fixed
+- support increase of infinity
+
 ## [0.2.0] - 2020-05-11
 
 ### Added
@@ -32,5 +37,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - good stuff
 
-[Unreleased]: https://github.com/kbrock/benchmark-sweet/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/kbrock/benchmark-sweet/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/kbrock/benchmark-sweet/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/kbrock/benchmark-sweet/compare/v0.0.1...v0.2.0

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -42,7 +42,11 @@ module Benchmark
       end
 
       def worst?
-        @worst ? stats.overlaps?(@worst) : (total.to_i - 1 == offset.to_i) && slowdown.to_i > 1
+        if @worst
+          stats.overlaps?(@worst)
+        else
+          slowdown == Float::INFINITY || (total.to_i - 1 == offset.to_i && slowdown.to_i > 1)
+         end
       end
 
       def slowdown

--- a/lib/benchmark/sweet/version.rb
+++ b/lib/benchmark/sweet/version.rb
@@ -1,5 +1,5 @@
 module Benchmark
   module Sweet
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
If the lowest entry has a value of 0, we end up with an
improvement of x/0 ==> Infinity, and we have trouble
comparing that value with other values

FIX: now properly handle infinity