### PR TITLE
Improve color support for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Or install it yourself as:
 ```ruby
 require "benchmark/sweet"
 require "active_support/all"
-require "more_core_extensions/all" # [].tabelize
 
 NSTRING = nil
 DELIMITER='/'.freeze
@@ -107,7 +106,6 @@ This is not a native value, it is specified when the items are specified (e.g.:`
 ```ruby
 require "benchmark/sweet"
 require "active_support/all"
-require "more_core_extensions/all" # [].tabelize
 
 NSTRING = nil
 DELIMITER='/'.freeze

--- a/benchmark-sweet.gemspec
+++ b/benchmark-sweet.gemspec
@@ -43,6 +43,5 @@ EOF
 
   spec.add_runtime_dependency "benchmark-ips", "~> 2.8.2"
   spec.add_runtime_dependency "memory_profiler", "~> 0.9.0"
-  spec.add_runtime_dependency "more_core_extensions" # for [].tabelize        - want to remove
   spec.add_runtime_dependency "activesupport"         # for {}.symbolize_keys! - want to remove
 end

--- a/examples/benchmark_big_small.rb
+++ b/examples/benchmark_big_small.rb
@@ -1,6 +1,5 @@
 require "benchmark/sweet"
 require "active_support/all"
-require "more_core_extensions/all" # [].tabelize
 
 # output:
 #

--- a/examples/benchmark_big_split.rb
+++ b/examples/benchmark_big_split.rb
@@ -1,6 +1,5 @@
 require 'benchmark/sweet'
 require 'active_support/all'
-require "more_core_extensions/all" # [].tabelize
 
 # version 2.3.7
 #

--- a/examples/benchmark_blank.rb
+++ b/examples/benchmark_blank.rb
@@ -1,6 +1,5 @@
 require "benchmark/sweet"
 require "active_support/all"
-require "more_core_extensions/all" # [].tabelize
 
 #  method             | NIL                    | EMPTY                  | FULL
 # --------------------+------------------------+------------------------+------------------------

--- a/examples/benchmark_rpt_database.rb
+++ b/examples/benchmark_rpt_database.rb
@@ -1,5 +1,4 @@
 require "benchmark/sweet"
-require "more_core_extensions/all"
 require "active_record"
 
 # For various versions of rails, compare `Model.all.first` vs `Model.all.to_a.first`

--- a/examples/benchmark_simple_database.rb
+++ b/examples/benchmark_simple_database.rb
@@ -1,5 +1,4 @@
 require "benchmark/sweet"
-require "more_core_extensions/all"
 require "active_record"
 #
 # label               | ips               | queries  | rows

--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -84,10 +84,28 @@ module Benchmark
     end
 
     def self.print_table(header_name, header_value, table_rows)
-      require "more_core_extensions" # defines tableize
       puts "", "#{header_name} #{header_value}", "" if header_value
-      # passing colummns to make sure table keeps the same column order
-      puts table_rows.tableize(:columns => table_rows.first.keys)
+      to_table(table_rows)
+    end
+
+    def self.to_table(arr)
+      field_sizes = Hash.new
+      arr.each { |row| field_sizes.merge!(row => row.map { |iterand| iterand[1].to_s.gsub(/\e\[[^m]+m/, '').length } ) }
+
+      column_sizes = arr.reduce([]) do |lengths, row|
+        row.each_with_index.map { |iterand, index| [lengths[index] || 0, field_sizes[row][index]].max }
+      end
+
+      format = column_sizes.collect {|n| "%#{n}s" }.join(" | ")
+      format += "\n"
+
+      printf format, *arr[0].each_with_index.map { |el, i| " "*(column_sizes[i] - field_sizes[arr[0]][i] ) + el[0].to_s }
+
+      printf format, *column_sizes.collect { |w| "-" * w }
+
+      arr[0..arr.count].each do |line|
+        printf format, *line.each_with_index.map { |el, i| " "*(column_sizes[i] - field_sizes[line][i] ) + el[1].to_s }
+      end
     end
   end
   extend Benchmark::Sweet


### PR DESCRIPTION
Fix tables to work better with color.

### Before

The column widths included the iso escape sequences for color which meant that the table columns were artificially high.

### After

The column widths are calculated without the iso escape sequences.
One dependency was removed.


![output](https://user-images.githubusercontent.com/1930/87373603-f7e49200-c557-11ea-9525-045f57015a89.png)
