### PR TITLE
total count bug

### DIFF
--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -58,6 +58,10 @@ module Benchmark
             row_data[column.call(comparison)] = value.call(comparison)
           end
         end
+
+        cols = table_rows.map(&:keys).uniq
+        table_rows = normalize_data(table_rows, cols) unless cols.count == 1
+
         if block_given?
           yield header_value, table_rows
         else
@@ -105,6 +109,16 @@ module Benchmark
 
       arr[0..arr.count].each do |line|
         printf format, *line.each_with_index.map { |el, i| " "*(column_sizes[i] - field_sizes[line][i] ) + el[1].to_s }
+      end
+    end
+
+    def self.normalize_data(rows, cols)
+      correct_row_count = cols.map(&:count).max
+      correct_rows = rows.detect { |r| r.count == correct_row_count}.keys
+      rows.each do |r|
+        next if r.count == correct_row_count
+
+        (correct_rows - r.keys).each { |missing_key| r.merge!(missing_key => nil)}
       end
     end
   end

--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -107,7 +107,7 @@ module Benchmark
 
       printf format, *column_sizes.collect { |w| "-" * w }
 
-      arr[0..arr.count].each do |line|
+      arr.each do |line|
         printf format, *line.each_with_index.map { |el, i| " "*(column_sizes[i] - field_sizes[line][i] ) + el[1].to_s }
       end
     end


### PR DESCRIPTION
`to_table` (`printf format, *arr[0].each_with_index.map { |el, i| " "*(column_sizes[i] - field_sizes[arr[0]][i] ) + el[0].to_s }`) assumes that all the data has the same totals which isn't necessarily correct (and especially not given [the blank example](https://github.com/kbrock/benchmark-sweet/blob/master/examples/benchmark_blank.rb#L12))

pared down reproducer from the linked example:

```
require "benchmark/sweet"
require "active_support/all"

ANIL=nil
EMPTY=[].freeze
FULL=["a"].freeze
VALUE_TO_S  = ->(m) { m.comp_short("\e[#{m.color}m#{m.central_tendency.round(1)} #{m.units}\e[0m") }

Benchmark.items(metrics: %w(ips)) do |x|
  x.metadata version: RUBY_VERSION
  x.metadata data: 'NIL' do
    x.report("x.blank?")           { ANIL.blank? }
  end

  x.metadata data: 'EMPTY' do
    x.report("x.blank?")           { EMPTY.blank? }
    x.report("x.empty?")           { EMPTY.empty? }
  end

  x.metadata data: 'FULL' do
    x.report("x.blank?")           { FULL.blank? }
    x.report("x.empty?")           { FULL.empty? }
  end

  x.compare_by :data
  x.report_with grouping: nil, row: :method, column: :data, value: VALUE_TO_S

  x.save_file (ENV["SAVE_FILE"] == "true") ? $0.sub(/\.rb$/, '.json') : ENV["SAVE_FILE"] if ENV["SAVE_FILE"]
end
```
----

i did say i would get back to this, and it's a little better than it was last time. for now would you consider merging as a temporary fix, and let me refactor over the shutdown (this ought to be before the processing [as you said in the revert commit that's last in history at the moment](https://github.com/kbrock/benchmark-sweet/pull/17)) ?

(this could’ve been done by uniq’ing the `base.map(&:totals)` but the column names are easier to get after we set the `table_rows` var, a fact which i'll deal with when i refactor)

as a note, i’d still like to refactor the table method itself as well but that’s for a different evening <sub><sup>except for the gook in the second commit, i'm sorry about that...</sup></sub>