### PR TITLE
minor formatting nits

### DIFF
--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -40,7 +40,7 @@ module Benchmark
 
       grouping = symbol_to_proc(grouping)
 
-      label_records = base.group_by(&grouping).select { |value, comparisons| !value.nil? }
+      label_records = base.group_by(&grouping).select { |value, _comparisons| !value.nil? }
       label_records = label_records.sort_by(&:first) if sort
 
       label_records.each(&block)
@@ -93,7 +93,7 @@ module Benchmark
       arr.each { |row| field_sizes.merge!(row => row.map { |iterand| iterand[1].to_s.gsub(/\e\[[^m]+m/, '').length } ) }
 
       column_sizes = arr.reduce([]) do |lengths, row|
-        row.each_with_index.map { |iterand, index| [lengths[index] || 0, field_sizes[row][index]].max }
+        row.each_with_index.map { |_iterand, index| [lengths[index] || 0, field_sizes[row][index]].max }
       end
 
       format = column_sizes.collect {|n| "%#{n}s" }.join(" | ")

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -46,7 +46,7 @@ module Benchmark
           stats.overlaps?(@worst)
         else
           slowdown == Float::INFINITY || (total.to_i - 1 == offset.to_i && slowdown.to_i > 1)
-         end
+        end
       end
 
       def slowdown

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -102,7 +102,7 @@ module Benchmark
       #   x.compare_by :data
       #
       def compare_by(*symbol, &block)
-        @grouping = symbol.empty? ? block : Proc.new { |label, value| symbol.map { |s| label[s] } }
+        @grouping = symbol.empty? ? block : Proc.new { |label, _value| symbol.map { |s| label[s] } }
       end
 
       # Setup the testing framework
@@ -213,8 +213,8 @@ module Benchmark
         relevant_entries.flat_map do |metric_name, metric_entries|
           # TODO: map these to Comparison(metric_name, label, stats) So we only have 1 type of lambda
           partitioned_metrics = grouping ? metric_entries.group_by(&grouping) : {nil => metric_entries}
-          partitioned_metrics.flat_map do |grouping_name, grouped_metrics|
-            sorted = grouped_metrics.sort_by { |n, e| e.central_tendency }
+          partitioned_metrics.flat_map do |_grouping_name, grouped_metrics|
+            sorted = grouped_metrics.sort_by { |_n, e| e.central_tendency }
             sorted.reverse! if HIGHER_BETTER.include?(metric_name)
 
             _best_label, best_stats = sorted.first

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -164,7 +164,6 @@ module Benchmark
         data = @entries.flat_map do |metric_name, metric_values|
           metric_values.map do |label, stat|
             # warnings
-            symbol_values ||= label.kind_of?(Hash) && label.values.detect { |v| v.nil? || v.kind_of?(Symbol) }
             {
               'name'    => label,
               'metric'  => metric_name,


### PR DESCRIPTION
please view by commit:

1) unused args with underscores
2) we're not using `symbol_values` anywhere else, do we need? (or can i change the comment to be a little more descriptive? i'm not sure `warnings` by itself is enough to justify this line...)
3) the indentation's off just a little 