### PR TITLE
Add capture sql to file for later comparison across versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,32 @@ x.report_with grouping: :version, sort: true, row: :method, column: [:data, :met
 As you might notice, the number of objects created for the runs are the same across versions.
 But the ips numbers may vary — letting you spot performance regressions.
 
+## SQL pattern capture with `save_sql`
+
+When benchmarking ActiveRecord code, `save_sql` captures the SQL queries executed during
+the `queries` metric pass and writes them to a diffable text file with EXPLAIN plans:
+
+```ruby
+Benchmark.items(metrics: %w(ips queries rows)) do |x|
+  x.metadata version: RUBY_VERSION
+  x.metadata data: "nil" do
+    x.report("to_s.split") { NSTRING.to_s.split(DELIMITER)           }
+    x.report("?split:[]")  { NSTRING ? NSTRING.split(DELIMITER) : [] }
+  end
+
+  x.save_file "results/split.json"
+  x.save_sql  "results/split.sql"
+end
+```
+
+SQL values are normalized to `?` so patterns are stable across runs. Duplicate queries
+within an operation are collapsed with a count. To compare across configurations or
+versions, generate one file per variant and diff:
+
+```bash
+diff results/v1.sql results/v2.sql
+```
+
 ## Custom value formatting
 
 Use the `value` parameter to customize cell display. This adds ANSI colors (green for best, red for worst):

--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -17,6 +17,7 @@ module Benchmark
       job.load_entries
       job.run
       job.save_entries
+      job.write_sql
 
       job.run_report
 

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -92,6 +92,16 @@ module Benchmark
         @filename = filename
       end
 
+      # Save SQL patterns and EXPLAIN plans to a diffable text file.
+      # Requires the queries metric to be enabled.
+      # @param filename [String] path to the output file (e.g. "results/mp1.sql")
+      # @param explain [Boolean] whether to run EXPLAIN on captured queries (default: true)
+      def save_sql(filename, explain: true)
+        @sql_filename = filename
+        @sql_entries = {}
+        @sql_explain = explain
+      end
+
       # &block - a lambda that accepts a label and a stats object
       # returns a unique object for each set of metrics that should be compared with each other
       #
@@ -145,6 +155,46 @@ module Benchmark
         JSON.load(IO.read(filename)).each do |v|
           n = normalize_label(v["name"].transform_keys(&:to_sym))
           add_entry n, v["metric"], v["samples"]
+        end
+
+      end
+
+      def write_sql(filename = @sql_filename)
+        return unless filename && @sql_entries&.any?
+
+        all_labels = @sql_entries.keys
+        all_keys = all_labels.first.keys
+        constant_keys = all_keys.select { |k| all_labels.map { |l| l[k] }.uniq.size == 1 }
+        varying_keys = all_keys - constant_keys
+
+        File.open(filename, "w") do |f|
+          constant_keys.each { |k| f.puts "# #{k}: #{all_labels.first[k]}" }
+          f.puts ""
+
+          @sql_entries.each do |label, queries|
+            header = varying_keys.map { |k| label[k] }.join(": ")
+            f.puts "== #{header} =="
+
+            if queries.empty?
+              f.puts "(no queries)"
+            else
+              # Group by normalized SQL to dedup, keep first raw entry for EXPLAIN
+              grouped = queries.each_with_object({}) do |(raw_sql, binds), hash|
+                normalized = normalize_sql(raw_sql)
+                hash[normalized] ||= { count: 0, raw_sql: raw_sql, binds: binds }
+                hash[normalized][:count] += 1
+              end
+
+              grouped.each do |normalized, info|
+                prefix = info[:count] > 1 ? "(#{info[:count]}x) " : ""
+                f.puts "SQL: #{prefix}#{normalized}"
+                if @sql_explain
+                  explain_sql(info[:raw_sql], info[:binds]).each { |line| f.puts "PLAN: #{line}" }
+                end
+              end
+            end
+            f.puts ""
+          end
         end
 
       end
@@ -231,6 +281,27 @@ module Benchmark
 
       def create_stats(samples)
         Benchmark::IPS::Stats::SD.new(Array(samples))
+      end
+
+      def normalize_sql(sql)
+        sql
+          .gsub(/'[^']*'/, "?")                    # quoted strings
+          .gsub(/= \d+/, "= ?")                    # = 123
+          .gsub(/IN \([\d, ]+\)/, "IN (?)")        # IN (1, 2, 3)
+          .gsub(/LIMIT \d+/, "LIMIT ?")            # LIMIT 1
+          .gsub(/OFFSET \d+/, "OFFSET ?")          # OFFSET 5
+          .gsub(/VALUES \([^)]+\)/, "VALUES (?)")  # VALUES (...)
+      end
+
+      def explain_sql(sql, binds = nil)
+        conn = ActiveRecord::Base.connection
+        if binds&.any?
+          conn.exec_query("EXPLAIN #{sql}", "EXPLAIN", binds).rows.map { |r| r.join(" ") }
+        else
+          conn.explain(sql).strip.split("\n")
+        end
+      rescue => e
+        ["EXPLAIN failed: #{e.message}"]
       end
     end
   end

--- a/lib/benchmark/sweet/queries.rb
+++ b/lib/benchmark/sweet/queries.rb
@@ -2,7 +2,7 @@ module Benchmark
   module Sweet
     module Queries
       def run_queries
-        cntr = ::Benchmark::Sweet::Queries::QueryCounter.new
+        cntr = ::Benchmark::Sweet::Queries::QueryCounter.new(capture_sql: !!@sql_filename)
         cntr.sub do
           items.each do |entry|
             entry.block.call
@@ -11,6 +11,7 @@ module Benchmark
             add_entry entry.label, "queries", values[:sql_count]
             add_entry entry.label, "ignored", values[:ignored_count]
             add_entry entry.label, "cached",  values[:cache_count]
+            @sql_entries[entry.label] = values[:sql_queries] if @sql_filename
             unless options[:quiet]
               printf "%20s: %3d queries %5d ar_objects", entry.label, values[:sql_count], values[:instance_count]
               printf " (%d ignored)", values[:ignored_count] if values[:ignored_count] > 0
@@ -34,7 +35,8 @@ module Benchmark
         IGNORED_STATEMENTS = %w(CACHE SCHEMA).freeze
         IGNORED_QUERIES    = /^(?:ROLLBACK|BEGIN|COMMIT|SAVEPOINT|RELEASE)/.freeze
 
-        def initialize
+        def initialize(capture_sql: false)
+          @capture_sql = capture_sql
           clear
         end
 
@@ -46,8 +48,9 @@ module Benchmark
               @instances[:ignored_count] += 1
             else
               @instances[:sql_count] += 1
+              @instances[:sql_queries] << [payload[:sql], payload[:type_casted_binds]] if @capture_sql
             end
-          else
+          elsif payload[:record_count]
             @instances[:instance_count] += payload[:record_count]
           end
         end
@@ -58,6 +61,7 @@ module Benchmark
 
         def clear
           @instances = {cache_count: 0, ignored_count: 0, sql_count: 0, instance_count: 0}
+          @instances[:sql_queries] = [] if @capture_sql
         end
 
         def get_clear; @instances.tap { clear }; end


### PR DESCRIPTION
This allows us to run multiple benchmarks and detect when the indexes or the sql no longer matches expectations.

A text file is much easier for longer term comparisons than storing in a json format.