### PR TITLE
Add all_same? and notable? to suppress false best/worst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `Comparison#all_same?` — true when all entries in a comparison group overlap (no meaningful differences)
+- `Comparison#notable?` — true when meaningful differences exist, useful for filtering uninteresting rows
+- `comparison_values` passes worst_stats to Comparison for best/worst boundary detection
+
+### Fixed
+- No longer marks best or worst when all entries are within error of each other
+- `worst?` returns false when the entry overlaps with the best (was incorrectly marking as worst)
+
 ## [0.3.0] - 2026-02-07
 
 ### Added

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -32,7 +32,8 @@ module Benchmark
         @mode ||= best? ? :best : overlaps? ? :same : diff_error ? :slowerish : :slower
       end
 
-      def best? ; !baseline || (baseline == stats) ; end
+      # @return true if this is the best entry AND it is distinguishable from the worst
+      def best? ; !baseline || (baseline == stats && !all_same?) ; end
 
       # @return true if it is basically the same as the best
       def overlaps?
@@ -42,11 +43,23 @@ module Benchmark
       end
 
       def worst?
+        return false if overlaps?
         if @worst
           stats.overlaps?(@worst)
         else
           slowdown == Float::INFINITY || (total.to_i - 1 == offset.to_i && slowdown > 1)
         end
+      end
+
+      # @return [Boolean] true if all entries in this comparison group overlap (no meaningful differences)
+      def all_same?
+        return false unless @worst && baseline
+        (baseline.central_tendency == @worst.central_tendency) || baseline.overlaps?(@worst)
+      end
+
+      # @return true if this row has meaningful differences worth displaying
+      def notable?
+        !all_same?
       end
 
       def slowdown

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -256,10 +256,11 @@ module Benchmark
             sorted.reverse! if HIGHER_BETTER.include?(metric_name)
 
             _best_label, best_stats = sorted.first
+            _worst_label, worst_stats = sorted.last
             total = sorted.count
 
             # TODO: fix ranking. i / total doesn't work as well when there is only 1 entry or some entries are the same
-            sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats) }
+            sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst_stats) }
           end
         end
       end

--- a/spec/benchmark/comparison_edge_spec.rb
+++ b/spec/benchmark/comparison_edge_spec.rb
@@ -40,10 +40,90 @@ RSpec.describe Benchmark::Sweet::Comparison do
     end
 
     it "uses custom worst when provided" do
-      stats = make_stats([100.0, 110.0])
-      worst = make_stats([100.0, 110.0])
-      comp = make_comparison("ips", {}, stats, 0, 2, stats, worst)
-      expect(comp.worst?).to be true
+      fast = make_stats([100.0, 102.0, 101.0, 100.5, 101.5])
+      mid  = make_stats([50.0, 52.0, 51.0, 50.5, 51.5])
+      slow = make_stats([10.0, 12.0, 11.0, 10.5, 11.5])
+      comp = make_comparison("ips", {}, mid, 1, 3, fast, slow)
+      expect(comp.worst?).to be false
+      comp2 = make_comparison("ips", {}, slow, 2, 3, fast, slow)
+      expect(comp2.worst?).to be true
+    end
+
+    it "returns false when overlapping with best" do
+      stats_a = make_stats([100.0, 102.0, 101.0])
+      stats_b = make_stats([99.0, 101.0, 100.0])
+      comp = make_comparison("ips", {}, stats_b, 1, 2, stats_a, stats_b)
+      expect(comp.worst?).to be false
+    end
+  end
+
+  describe "#all_same?" do
+    it "returns true when best and worst overlap" do
+      stats_a = make_stats([100.0, 102.0, 101.0])
+      stats_b = make_stats([99.0, 101.0, 100.0])
+      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
+      expect(comp.all_same?).to be true
+    end
+
+    it "returns true when best and worst have identical single samples" do
+      stats_a = make_stats([1.0])
+      stats_b = make_stats([1.0])
+      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, stats_b)
+      expect(comp.all_same?).to be true
+    end
+
+    it "returns false when best and worst are distinct" do
+      fast = make_stats([100.0, 110.0, 105.0])
+      slow = make_stats([10.0, 11.0, 10.5])
+      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
+      expect(comp.all_same?).to be false
+    end
+
+    it "returns false when single samples differ" do
+      stats_a = make_stats([1.0])
+      stats_b = make_stats([2.0])
+      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, stats_b)
+      expect(comp.all_same?).to be false
+    end
+
+    it "returns false when worst is not provided" do
+      stats = make_stats([100.0])
+      comp = make_comparison("ips", {}, stats, 0, 1, stats)
+      expect(comp.all_same?).to be false
+    end
+  end
+
+  describe "#best? with all_same?" do
+    it "returns false when all entries overlap" do
+      stats_a = make_stats([100.0, 102.0, 101.0])
+      stats_b = make_stats([99.0, 101.0, 100.0])
+      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
+      expect(comp.best?).to be false
+      expect(comp.mode).to eq(:same)
+    end
+
+    it "returns true when entries are distinct" do
+      fast = make_stats([100.0, 110.0, 105.0])
+      slow = make_stats([10.0, 11.0, 10.5])
+      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
+      expect(comp.best?).to be true
+      expect(comp.mode).to eq(:best)
+    end
+  end
+
+  describe "#notable?" do
+    it "returns false when all entries overlap" do
+      stats_a = make_stats([100.0, 102.0, 101.0])
+      stats_b = make_stats([99.0, 101.0, 100.0])
+      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
+      expect(comp.notable?).to be false
+    end
+
+    it "returns true when entries are distinct" do
+      fast = make_stats([100.0, 110.0, 105.0])
+      slow = make_stats([10.0, 11.0, 10.5])
+      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
+      expect(comp.notable?).to be true
     end
   end
 


### PR DESCRIPTION
## Summary
- When all entries in a comparison group overlap, none are marked best or worst — no more misleading bold/color on tables where values are effectively identical (e.g., query counts)
- `best?` returns false when all entries are within error of each other
- `worst?` returns false when the entry overlaps with best
- `all_same?` checks both central_tendency equality (single-sample stats with zero error) and statistical overlap
- `notable?` returns true only when meaningful differences exist, useful for filtering uninteresting rows
- `comparison_values` now passes `worst_stats` to Comparison so it can detect when best≈worst

## Test plan
- [x] Existing tests pass (115 examples, 0 failures)
- [x] New edge case tests for all_same?, notable?, best?/worst? suppression
- [x] Single-sample identical values (query counts) correctly detected as all_same

🤖 Generated with [Claude Code](https://claude.com/claude-code)