### PR TITLE
Add skip_unremarkable! to filter uninteresting comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `Comparison#all_same?` — true when all entries in a comparison group overlap (no meaningful differences)
-- `Comparison#notable?` — true when meaningful differences exist, useful for filtering uninteresting rows
+- `Job#skip_unremarkable!` — filters out comparison groups where all entries are within error of each other
 - `comparison_values` passes worst_stats to Comparison for best/worst boundary detection
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -322,6 +322,35 @@ versions, generate one file per variant and diff:
 diff results/v1.sql results/v2.sql
 ```
 
+## Filtering unremarkable rows with `skip_unremarkable!`
+
+When comparing many configurations, some operations may show no meaningful difference —
+all entries are within error of each other. `skip_unremarkable!` removes these from the output
+so you can focus on what actually matters:
+
+```ruby
+Benchmark.items(metrics: %w(ips queries rows)) do |x|
+  x.compare_by :operation
+  x.report_with row: :operation, column: :config, grouping: :shape
+  x.skip_unremarkable!
+
+  x.metadata(config: "mp1") do
+    x.report(operation: "parent")      { node.parent }
+    x.report(operation: "descendants") { node.descendants.to_a }
+  end
+  x.metadata(config: "mp2") do
+    x.report(operation: "parent")      { node.parent }
+    x.report(operation: "descendants") { node.descendants.to_a }
+  end
+end
+```
+
+If `parent` returns the same IPS and query count for both mp1 and mp2, that row is
+dropped entirely. Only `descendants` — where the configs actually differ — appears in the table.
+
+This works per comparison group: if queries are identical but IPS differs, the IPS row
+is kept and the queries row is dropped.
+
 ## Custom value formatting
 
 Use the `value` parameter to customize cell display. This adds ANSI colors (green for best, red for worst):

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -57,11 +57,6 @@ module Benchmark
         (baseline.central_tendency == @worst.central_tendency) || baseline.overlaps?(@worst)
       end
 
-      # @return true if this row has meaningful differences worth displaying
-      def notable?
-        !all_same?
-      end
-
       def slowdown
         return @slowdown if @slowdown
         @slowdown, @diff_error = stats.slowdown(baseline)

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -48,6 +48,7 @@ module Benchmark
         @grouping = nil
         @report_options = {}
         @report_block = nil
+        @skip_unremarkable = false
         # current item metadata
         @meta = {}
       end
@@ -113,6 +114,11 @@ module Benchmark
       #
       def compare_by(*symbol, &block)
         @grouping = symbol.empty? ? block : Proc.new { |label, _value| symbol.map { |s| label[s] } }
+      end
+
+      # Skip comparisons where all entries are within error of each other
+      def skip_unremarkable!
+        @skip_unremarkable = true
       end
 
       # Setup the testing framework
@@ -260,7 +266,8 @@ module Benchmark
             total = sorted.count
 
             # TODO: fix ranking. i / total doesn't work as well when there is only 1 entry or some entries are the same
-            sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst_stats) }
+            comparisons = sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst_stats) }
+            @skip_unremarkable && comparisons.first&.all_same? ? [] : comparisons
           end
         end
       end

--- a/spec/benchmark/comparison_edge_spec.rb
+++ b/spec/benchmark/comparison_edge_spec.rb
@@ -111,22 +111,6 @@ RSpec.describe Benchmark::Sweet::Comparison do
     end
   end
 
-  describe "#notable?" do
-    it "returns false when all entries overlap" do
-      stats_a = make_stats([100.0, 102.0, 101.0])
-      stats_b = make_stats([99.0, 101.0, 100.0])
-      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
-      expect(comp.notable?).to be false
-    end
-
-    it "returns true when entries are distinct" do
-      fast = make_stats([100.0, 110.0, 105.0])
-      slow = make_stats([10.0, 11.0, 10.5])
-      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
-      expect(comp.notable?).to be true
-    end
-  end
-
   describe "#comp_string" do
     it "formats best entry" do
       stats = make_stats([100.0])

--- a/spec/benchmark/job_spec.rb
+++ b/spec/benchmark/job_spec.rb
@@ -136,6 +136,71 @@ RSpec.describe Benchmark::Sweet::Job do
     end
   end
 
+  describe "#skip_unremarkable!" do
+    it "removes comparisons where all entries are the same" do
+      job = described_class.new(metrics: %w(queries))
+      job.add_entry({operation: "parent"}, "queries", [1.0])
+      job.add_entry({operation: "children"}, "queries", [1.0])
+      job.skip_unremarkable!
+
+      comparisons = job.comparison_values
+      expect(comparisons).to be_empty
+    end
+
+    it "keeps comparisons where entries differ" do
+      job = described_class.new(metrics: %w(ips))
+      job.add_entry({operation: "fast"}, "ips", [1000.0])
+      job.add_entry({operation: "slow"}, "ips", [100.0])
+      job.skip_unremarkable!
+
+      comparisons = job.comparison_values
+      expect(comparisons.length).to eq(2)
+    end
+
+    it "filters per comparison group with compare_by" do
+      job = described_class.new(metrics: %w(queries))
+      job.compare_by :shape
+
+      # wide: both have 1 query — unremarkable
+      job.add_entry({shape: "wide", operation: "parent"}, "queries", [1.0])
+      job.add_entry({shape: "wide", operation: "children"}, "queries", [1.0])
+      # deep: different query counts — remarkable
+      job.add_entry({shape: "deep", operation: "parent"}, "queries", [1.0])
+      job.add_entry({shape: "deep", operation: "children"}, "queries", [3.0])
+      job.skip_unremarkable!
+
+      comparisons = job.comparison_values
+      # Only deep comparisons survive
+      expect(comparisons.length).to eq(2)
+      expect(comparisons.map { |c| c[:shape] }.uniq).to eq(["deep"])
+    end
+
+    it "keeps only groups with meaningful differences" do
+      job = described_class.new(metrics: %w(ips))
+      job.compare_by :operation
+
+      # parent: mp1 and mp2 are the same — unremarkable
+      job.add_entry({operation: "parent", config: "mp1"}, "ips", [10_000.0])
+      job.add_entry({operation: "parent", config: "mp2"}, "ips", [10_000.0])
+      # descendants: mp1 and mp2 differ — remarkable
+      job.add_entry({operation: "descendants", config: "mp1"}, "ips", [1000.0])
+      job.add_entry({operation: "descendants", config: "mp2"}, "ips", [5000.0])
+      job.skip_unremarkable!
+
+      comparisons = job.comparison_values
+      expect(comparisons.map { |c| c[:operation] }.uniq).to eq(["descendants"])
+    end
+
+    it "does not filter when not enabled" do
+      job = described_class.new(metrics: %w(queries))
+      job.add_entry({operation: "parent"}, "queries", [1.0])
+      job.add_entry({operation: "children"}, "queries", [1.0])
+
+      comparisons = job.comparison_values
+      expect(comparisons.length).to eq(2)
+    end
+  end
+
   describe "serialization" do
     it "round-trips entries through save and load" do
       Tempfile.create(["benchmark", ".json"]) do |f|


### PR DESCRIPTION
## Summary
- `skip_unremarkable!` removes comparison groups where all entries are within error — reduces noise in tables where most operations show identical results
- Drops `notable?` (was just `!all_same?`, use `all_same?` directly)
- Documented in README with example showing config comparison filtering

## Test plan
- [x] 120 examples, 0 failures
- [x] Tests for: basic filtering, per-group filtering with compare_by, keeps remarkable groups, no-op when disabled
- [x] Empty comparison list handled cleanly (no crash, no empty tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)