### PR TITLE
Add comp_bar and colorize to Comparison

### DIFF
--- a/examples/benchmark_bar.rb
+++ b/examples/benchmark_bar.rb
@@ -1,0 +1,14 @@
+require 'benchmark/sweet'
+
+STRING = "Hello, World! This is a benchmark test string."
+
+Benchmark.items(metrics: %w(ips), warmup: 1, time: 2, quiet: true, force: true) do |x|
+  x.report("downcase")    { STRING.downcase }
+  x.report("swapcase")    { STRING.swapcase }
+  x.report("reverse")     { STRING.reverse }
+  x.report("tr")          { STRING.tr('aeiou', '*') }
+  x.report("gsub")        { STRING.gsub(/[aeiou]/, '*') }
+
+  x.report_with row: :method, column: :metric,
+    value: ->(m) { m.comp_bar(color: true) }
+end

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -17,6 +17,7 @@ module Benchmark
       def [](field)
         case field
         when :metric      then metric
+        when :comp_bar    then comp_bar
         when :comp_short  then comp_short
         when :comp_string then comp_string
         when :label       then label  # not sure if this one makes sense
@@ -83,18 +84,25 @@ module Benchmark
         end
       end
 
-      # I tend to call with:
-      #   c.comp_short("\033[#{c.color}m#{c.central_tendency.round(1)} #{c.units}\e[0m") # "\033[31m#{value}\e[0m"
-      def comp_short(value = nil)
+      def comp_short(value = nil, color: false)
         value ||= "#{central_tendency.round(1)} #{units}"
-        case mode
+        result = case mode
         when :best, :same
           value
-        when :slower 
+        when :slower
           "%s - %.2fx (± %.2f)" % [value, slowdown, error]
         when :slowerish
           "%s - %.2fx" % [value, slowdown]
         end
+        color ? colorize(result) : result
+      end
+
+      def comp_bar(width: 20, color: false)
+        fill = (baseline && !overlaps?) ? (width.to_f / slowdown).round : width
+        fill = fill.clamp(0, width)
+        shade = width - fill
+        bar = "█" * fill + "░" * shade
+        color ? colorize(bar) : bar
       end
 
       def color
@@ -107,6 +115,10 @@ module Benchmark
         else
           ";0"
         end
+      end
+
+      def colorize(str)
+        "\e[#{color}m#{str}\e[0m"
       end
     end
   end

--- a/spec/benchmark/comparison_spec.rb
+++ b/spec/benchmark/comparison_spec.rb
@@ -95,6 +95,75 @@ RSpec.describe Benchmark::Sweet::Comparison do
     end
   end
 
+  describe "#comp_short with color" do
+    it "returns plain text by default" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 1, fast_stats)
+      expect(comp.comp_short).not_to include("\e[")
+    end
+
+    it "wraps in ANSI color when color: true" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      result = comp.comp_short(color: true)
+      expect(result).to start_with("\e[32m")
+      expect(result).to end_with("\e[0m")
+    end
+
+    it "wraps slower entries in red when color: true" do
+      comp = make_comparison("ips", {method: "slow"}, slow_stats, 1, 2, fast_stats)
+      result = comp.comp_short(color: true)
+      expect(result).to include("\e[")
+      expect(result).to end_with("\e[0m")
+    end
+  end
+
+  describe "#comp_bar" do
+    it "returns a full solid bar for best" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      result = comp.comp_bar(width: 10)
+      expect(result).to eq("██████████")
+    end
+
+    it "returns a full solid bar when no baseline" do
+      comp = make_comparison("ips", {method: "only"}, fast_stats, 0, 1, nil)
+      result = comp.comp_bar(width: 10)
+      expect(result).to eq("██████████")
+    end
+
+    it "returns a partial bar with shading for slower entries" do
+      comp = make_comparison("ips", {method: "slow"}, slow_stats, 1, 2, fast_stats)
+      result = comp.comp_bar(width: 10)
+      expect(result).to include("█")
+      expect(result).to include("░")
+      expect(result.length).to eq(10)
+    end
+
+    it "returns a full solid bar for overlapping entries" do
+      comp = make_comparison("ips", {method: "same"}, same_stats, 1, 2, fast_stats)
+      result = comp.comp_bar(width: 10)
+      expect(result).to eq("██████████")
+    end
+
+    it "wraps in ANSI color when color: true" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      result = comp.comp_bar(width: 10, color: true)
+      expect(result).to start_with("\e[32m")
+      expect(result).to end_with("\e[0m")
+    end
+
+    it "returns plain text when color: false" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      result = comp.comp_bar(width: 10, color: false)
+      expect(result).not_to include("\e[")
+    end
+  end
+
+  describe "#colorize" do
+    it "wraps string in ANSI color code" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      expect(comp.colorize("hello")).to eq("\e[32mhello\e[0m")
+    end
+  end
+
   describe "#[]" do
     let(:label) { {method: "fast", data: "nil"} }
     let(:comp) { make_comparison("ips", label, fast_stats, 0, 1, fast_stats) }


### PR DESCRIPTION
## Summary
- Add `comp_bar(width:, color:)` for proportional unicode bar chart visualization
- Add `colorize` helper to centralize ANSI color wrapping
- Add `color:` keyword to `comp_short` for optional ANSI coloring
- Best/overlapping entries get full solid bars; slower entries get proportional fill with shading

## Test plan
- [x] Unit tests for comp_bar (best, no baseline, slower, overlapping, color on/off)
- [x] Unit tests for comp_short color keyword
- [x] Unit test for colorize helper
- [x] Full suite passes (130 examples, 0 failures)
- [ ] Visual check: `bundle exec ruby examples/benchmark_bar.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)