### PR TITLE
MarkdownReport: pass color: false to value formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,36 @@ is kept and the queries row is dropped.
 
 ## Custom value formatting
 
-Use the `value` parameter to customize cell display. This adds ANSI colors (green for best, red for worst):
+Use the `value` parameter to customize cell display. `Comparison#comp_short` is the default formatter and already accepts a `color:` kwarg — wrap it in a lambda that respects the color flag from the report:
 
 ```ruby
-VALUE_TO_S = ->(m) { m.comp_short("\e[#{m.color}m#{m.central_tendency.round(1)} #{m.units}\e[0m") }
-x.report_with row: :method, column: :metric, value: VALUE_TO_S
+VALUE = ->(c, color: false) { c.comp_short(color: color) }
+x.report_with row: :method, column: :metric, value: VALUE
 ```
+
+To show only the value without slowdown text:
+
+```ruby
+VALUE = ->(c, color: false) {
+  c.comp_short("#{c.central_tendency.round(1)} #{c.units}", color: color)
+}
+```
+
+`comp_short(value, color:)` takes an optional pre-formatted value (defaults to `"<central_tendency> <units>"`), appends slowdown info for non-best entries, and applies color if requested.
+
+Reports decide whether to pass `color: true`:
+
+- **HtmlReport** — `color: true` when 4+ columns (color helps scan many options); plain when 2-3 columns (just bolds the best)
+- **MarkdownReport** — always plain (markdown files don't render ANSI escapes)
+- **Default stdout** — plain
+
+If your formatter unconditionally adds ANSI codes (instead of respecting `color:`), they will appear as garbage in markdown files.
+
+### Output destinations
+
+- `x.format(:markdown)` / `x.format(:html)` — choose the report format (default: `:markdown`)
+- `x.report_output("path.md")` — write to file instead of stdout
+- `x.report_output(nil)` or omitted — write to stdout
 
 ## Options
 

--- a/lib/benchmark/sweet/markdown_report.rb
+++ b/lib/benchmark/sweet/markdown_report.rb
@@ -25,8 +25,6 @@ module Benchmark
       def print_table(header_value, table_rows, out: $stdout)
         return if table_rows.empty?
 
-        strip_ansi = ->(s) { s.to_s.gsub(/\e\[[^m]*m/, '') }
-
         headers = table_rows.flat_map(&:keys).uniq
 
         formatted_rows = table_rows.map do |row_data|
@@ -35,7 +33,7 @@ module Benchmark
             if val.nil?
               ""
             elsif val.is_a?(Benchmark::Sweet::Comparison)
-              value.call(val)
+              value.call(val, color: false)
             else
               val.to_s
             end
@@ -43,14 +41,13 @@ module Benchmark
         end
 
         widths = headers.each_with_index.map do |h, i|
-          values_max = formatted_rows.map { |r| strip_ansi.call(r[i]).length }.max || 0
-          [strip_ansi.call(h.to_s).length, values_max, 3].max
+          values_max = formatted_rows.map { |r| r[i].length }.max || 0
+          [h.to_s.length, values_max, 3].max
         end
 
         pad = ->(str, width, right) {
-          visible = strip_ansi.call(str).length
-          padding = " " * [width - visible, 0].max
-          right ? padding + str.to_s : str.to_s + padding
+          padding = " " * [width - str.length, 0].max
+          right ? padding + str : str + padding
         }
 
         out.puts "", "#{header_value}", "" if header_value
@@ -61,9 +58,8 @@ module Benchmark
         end
       end
 
-      def render_cell(c)
-        value = format_number(c.central_tendency)
-        c.colorize("#{value} #{c.units}")
+      def render_cell(c, color: false)
+        c.comp_short("#{format_number(c.central_tendency)} #{c.units}", color: color)
       end
 
       def format_number(num)


### PR DESCRIPTION
Markdown output corrupts when callers supply a value formatter that adds ANSI color codes — the escapes pass through and render as garbage on GitHub.

**Before** (custom formatter that always colorizes):
```
has_parent? |  [31m4,795,914.0 i/s[0m |  [32m5,458,960.0 i/s[0m
```

**After:**
```
has_parent? | 4,795,914.0 i/s | 5,458,960.0 i/s
```

The fix follows the convention `HtmlReport` already uses: pass `color:` as a kwarg to the value formatter so it can decide. `MarkdownReport` defaults to `color: false`.

- `MarkdownReport#print_table` calls `value.call(val, color: false)` instead of `value.call(val)`
- `MarkdownReport#render_cell` accepts `color: false` and delegates to `comp_short(color: color)` (removes duplicated colorize logic)
- README documents the value formatter convention so callers know to accept `color:`
- Out of scope: terminal output unchanged, `HtmlReport` unchanged