### PR TITLE
Add Charts and multiple fields per cell

### DIFF
--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -47,16 +47,26 @@ module Benchmark
       label_records.each(&block)
     end
 
-    def self.table(base, grouping: nil, sort: false, row: :label, column: :metric, value: :comp_short)
+    def self.table(base, grouping: nil, sort: false, row: :label, column: :metric, cell: nil, value: :comp_short)
       header_name = grouping.respond_to?(:call) ? "grouping" : grouping
       column = symbol_to_proc(column)
+      cell_proc = symbol_to_proc(cell) if cell
       value = symbol_to_proc(value)
 
       group(base, grouping, sort: true) do |header_value, table_comparisons|
         row_key = row.kind_of?(Symbol) || row.kind_of?(String) ? row : "label"
         table_rows = group(table_comparisons, row, sort: sort).map do |row_header, row_comparisons|
-          row_comparisons.each_with_object({row_key => row_header}) do |comparison, row_data|
-            row_data[column.call(comparison)] = value.call(comparison)
+          if cell_proc
+            # Collect comparisons into a hash keyed by cell value per (row, column) position
+            row_comparisons.each_with_object({row_key => row_header}) do |comparison, row_data|
+              col_key = column.call(comparison)
+              cell_key = cell_proc.call(comparison)
+              (row_data[col_key] ||= {})[cell_key] = comparison
+            end
+          else
+            row_comparisons.each_with_object({row_key => row_header}) do |comparison, row_data|
+              row_data[column.call(comparison)] = value.call(comparison)
+            end
           end
         end
         yield header_value, table_rows

--- a/lib/benchmark/sweet/chart_report.rb
+++ b/lib/benchmark/sweet/chart_report.rb
@@ -3,7 +3,9 @@
 module Benchmark
   module Sweet
     class ChartReport
-      attr_accessor :grouping, :row, :column, :sort, :value, :title, :baseline
+      attr_accessor :grouping, :row, :column, :sort, :value, :title, :baseline, :cell
+      # bar/line/scatter: metric names (Symbol or Array) for chart type mapping
+      attr_accessor :bar, :line, :scatter
 
       def initialize
         @grouping = nil
@@ -13,14 +15,22 @@ module Benchmark
         @value = nil # unused for charts, kept for interface compatibility
         @title = "Benchmark Report"
         @baseline = nil
+        @cell = nil
+        @bar = nil
+        @line = nil
+        @scatter = nil
       end
 
       def render(comparisons, io)
         charts = []
 
-        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, value: -> c { c }, sort: sort) do |header_value, table_rows|
+        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, cell: cell, value: -> c { c }, sort: sort) do |header_value, table_rows|
           next if table_rows.empty?
-          charts << build_chart_data(header_value, table_rows)
+          if @cell
+            charts << build_multi_metric_chart(header_value, table_rows)
+          else
+            charts << build_chart_data(header_value, table_rows)
+          end
         end
 
         io.puts wrap_document(title, charts)
@@ -61,6 +71,60 @@ module Benchmark
         }
       end
 
+      # Build chart when cell: :metric is set. Each cell is a hash of {metric => Comparison}.
+      # bar/line attrs control which metric renders as which type.
+      def build_multi_metric_chart(header_value, table_rows)
+        headers = table_rows.flat_map(&:keys).uniq
+        row_key = headers.first
+        column_keys = headers[1..]
+
+        labels = table_rows.map { |r| r[row_key].to_s }
+
+        all_metrics = Array(@bar) + Array(@line) + Array(@scatter)
+        axis_ids = all_metrics.each_with_index.to_h { |m, i| [m.to_s, "y#{i > 0 ? i : ""}"] }
+        positions = all_metrics.each_with_index.to_h { |m, i| [m.to_s, i.even? ? "left" : "right"] }
+
+        line_metrics = Array(@line)
+        scatter_metrics = Array(@scatter)
+
+        datasets = []
+        scales = {}
+
+        column_keys.each do |col|
+          all_metrics.each do |metric|
+            metric_s = metric.to_s
+            chart_type = if scatter_metrics.include?(metric) then "scatter"
+                         elsif line_metrics.include?(metric) then "line"
+                         else "bar"
+                         end
+            axis_id = axis_ids[metric_s]
+
+            values = table_rows.map do |r|
+              c = r[col]&.dig(metric_s)
+              next nil unless c
+              c.ratio ? c.ratio.round(4) : c.central_tendency.round(2)
+            end
+            next if values.all?(&:nil?)
+
+            sample = table_rows.lazy.filter_map { |r| r[col]&.dig(metric_s) }.first
+            ds = { label: "#{col} #{metric_s}", data: values, type: chart_type, yAxisID: axis_id }
+            ds[:fill] = false if chart_type == "line"
+            ds[:borderWidth] = 2 if chart_type == "line"
+            datasets << ds
+
+            axis_title = sample&.ratio ? "relative to #{@baseline}" : (sample&.units || "")
+            scales[axis_id] ||= { position: positions[metric_s], title: axis_title, beginAtZero: true }
+          end
+        end
+
+        {
+          title: header_value.to_s,
+          labels: labels,
+          datasets: datasets,
+          scales: scales,
+        }
+      end
+
       def escape(str)
         str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
       end
@@ -69,6 +133,13 @@ module Benchmark
         js = +""
         charts.each_with_index do |chart, i|
           canvas_id = "chart-#{i}"
+          scales_js = if chart[:scales]
+            chart[:scales].map do |id, cfg|
+              "#{id}: { position: #{cfg[:position].inspect}, beginAtZero: true, title: { display: true, text: #{cfg[:title].inspect} } }"
+            end.join(", ")
+          else
+            "y: { beginAtZero: true, title: { display: true, text: #{(chart[:units] || "").inspect} } }"
+          end
           js << <<~JS
             new Chart(document.getElementById('#{canvas_id}'), {
               type: 'bar',
@@ -86,15 +157,7 @@ module Benchmark
                   },
                   legend: { position: 'top' }
                 },
-                scales: {
-                  y: {
-                    beginAtZero: true,
-                    title: {
-                      display: true,
-                      text: #{chart[:units].inspect}
-                    }
-                  }
-                }
+                scales: { #{scales_js} }
               }
             });
           JS
@@ -105,7 +168,18 @@ module Benchmark
       def datasets_json(datasets)
         entries = datasets.map do |ds|
           data_str = ds[:data].map { |v| v.nil? ? "null" : v.to_s }.join(", ")
-          "{ label: #{ds[:label].inspect}, data: [#{data_str}] }"
+          parts = ["label: #{ds[:label].inspect}", "data: [#{data_str}]"]
+          parts << "type: #{ds[:type].inspect}" if ds[:type]
+          parts << "yAxisID: #{ds[:yAxisID].inspect}" if ds[:yAxisID]
+          case ds[:type]
+          when "line"
+            parts << "fill: false"
+            parts << "borderWidth: 2"
+          when "scatter"
+            parts << "pointRadius: 5"
+            parts << "showLine: false"
+          end
+          "{ #{parts.join(", ")} }"
         end
         "[#{entries.join(", ")}]"
       end

--- a/lib/benchmark/sweet/chart_report.rb
+++ b/lib/benchmark/sweet/chart_report.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module Benchmark
+  module Sweet
+    class ChartReport
+      attr_accessor :grouping, :row, :column, :sort, :value, :title, :baseline
+
+      def initialize
+        @grouping = nil
+        @row = :label
+        @column = :metric
+        @sort = false
+        @value = nil # unused for charts, kept for interface compatibility
+        @title = "Benchmark Report"
+        @baseline = nil
+      end
+
+      def render(comparisons, io)
+        charts = []
+
+        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, value: -> c { c }, sort: sort) do |header_value, table_rows|
+          next if table_rows.empty?
+          charts << build_chart_data(header_value, table_rows)
+        end
+
+        io.puts wrap_document(title, charts)
+      end
+
+      private
+
+      def build_chart_data(header_value, table_rows)
+        headers = table_rows.flat_map(&:keys).uniq
+        row_key = headers.first
+        column_keys = headers[1..]
+
+        labels = table_rows.map { |r| r[row_key].to_s }
+
+        use_ratio = table_rows.any? { |r| column_keys.any? { |c| r[c]&.ratio } }
+
+        datasets = column_keys.map do |col|
+          values = table_rows.map do |r|
+            c = r[col]
+            next nil unless c
+            use_ratio ? c.ratio&.round(4) : c.central_tendency.round(2)
+          end
+          { label: col.to_s, data: values }
+        end
+
+        units = if use_ratio
+                  "relative to #{@baseline}"
+                else
+                  sample = table_rows.lazy.filter_map { |r| column_keys.lazy.filter_map { |c| r[c] }.first }.first
+                  sample&.units || ""
+                end
+
+        {
+          title: header_value.to_s,
+          labels: labels,
+          datasets: datasets,
+          units: units,
+        }
+      end
+
+      def escape(str)
+        str.to_s.gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;").gsub('"', "&quot;")
+      end
+
+      def charts_js(charts)
+        js = +""
+        charts.each_with_index do |chart, i|
+          canvas_id = "chart-#{i}"
+          js << <<~JS
+            new Chart(document.getElementById('#{canvas_id}'), {
+              type: 'bar',
+              data: {
+                labels: #{chart[:labels].map(&:to_s).inspect},
+                datasets: #{datasets_json(chart[:datasets])}
+              },
+              options: {
+                responsive: true,
+                plugins: {
+                  title: {
+                    display: true,
+                    text: #{chart[:title].inspect},
+                    font: { size: 14, weight: '600' }
+                  },
+                  legend: { position: 'top' }
+                },
+                scales: {
+                  y: {
+                    beginAtZero: true,
+                    title: {
+                      display: true,
+                      text: #{chart[:units].inspect}
+                    }
+                  }
+                }
+              }
+            });
+          JS
+        end
+        js
+      end
+
+      def datasets_json(datasets)
+        entries = datasets.map do |ds|
+          data_str = ds[:data].map { |v| v.nil? ? "null" : v.to_s }.join(", ")
+          "{ label: #{ds[:label].inspect}, data: [#{data_str}] }"
+        end
+        "[#{entries.join(", ")}]"
+      end
+
+      def wrap_document(doc_title, charts)
+        canvases = charts.each_with_index.map do |_chart, i|
+          "    <div class=\"chart-container\"><canvas id=\"chart-#{i}\"></canvas></div>"
+        end.join("\n")
+
+        <<~HTML
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>#{escape(doc_title)}</title>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+            <style>
+              body {
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                background: #fff;
+                color: #1f2328;
+                max-width: 960px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+              }
+              h1 { font-size: 1.5rem; font-weight: 600; }
+              .chart-container {
+                margin: 1.5rem 0;
+                position: relative;
+                height: 400px;
+              }
+            </style>
+          </head>
+          <body>
+            <h1>#{escape(doc_title)}</h1>
+          #{canvases}
+            <script>
+          #{charts_js(charts)}
+            </script>
+          </body>
+          </html>
+        HTML
+      end
+    end
+  end
+end

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -1,7 +1,7 @@
 module Benchmark
   module Sweet
     class Comparison
-      UNITS = {"ips" => "i/s", "memsize" => "bytes", "memsize_retained" => "bytes"}.freeze
+      UNITS = {"ips" => "i/s", "memsize" => "bytes", "memsize_retained" => "bytes", "queries" => "queries", "rows" => "rows", "cached" => "queries"}.freeze
       attr_reader :label, :metric, :stats, :best, :worst, :reference
       attr_reader :offset, :total
       def initialize(metric, label, stats, offset, total, best, worst: nil, reference: nil)
@@ -18,6 +18,7 @@ module Benchmark
       # Value relative to a named baseline. >1.0 = faster/better, <1.0 = slower/worse.
       def ratio
         return nil unless @reference
+        return nil if @reference.central_tendency == 0
         stats.central_tendency / @reference.central_tendency
       end
 

--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -2,16 +2,23 @@ module Benchmark
   module Sweet
     class Comparison
       UNITS = {"ips" => "i/s", "memsize" => "bytes", "memsize_retained" => "bytes"}.freeze
-      attr_reader :label, :metric, :stats, :baseline, :worst
+      attr_reader :label, :metric, :stats, :best, :worst, :reference
       attr_reader :offset, :total
-      def initialize(metric, label, stats, offset, total, baseline, worst = nil)
+      def initialize(metric, label, stats, offset, total, best, worst: nil, reference: nil)
         @metric = metric
         @label = label
         @stats = stats
         @offset = offset
         @total = total
-        @baseline = baseline
+        @best = best
         @worst = worst
+        @reference = reference
+      end
+
+      # Value relative to a named baseline. >1.0 = faster/better, <1.0 = slower/worse.
+      def ratio
+        return nil unless @reference
+        stats.central_tendency / @reference.central_tendency
       end
 
       def [](field)
@@ -34,13 +41,13 @@ module Benchmark
       end
 
       # @return true if this is the best entry AND it is distinguishable from the worst
-      def best? ; !baseline || (baseline == stats && !all_same?) ; end
+      def best? ; !best || (best == stats && !all_same?) ; end
 
       # @return true if it is basically the same as the best
       def overlaps?
         return @overlaps if defined?(@overlaps)
         @overlaps = slowdown == 1 ||
-                      stats && baseline && (stats.central_tendency == baseline.central_tendency || stats.overlaps?(baseline))
+                      stats && best && (stats.central_tendency == best.central_tendency || stats.overlaps?(best))
       end
 
       def worst?
@@ -54,13 +61,13 @@ module Benchmark
 
       # @return [Boolean] true if all entries in this comparison group overlap (no meaningful differences)
       def all_same?
-        return false unless @worst && baseline
-        (baseline.central_tendency == @worst.central_tendency) || baseline.overlaps?(@worst)
+        return false unless @worst && best
+        (best.central_tendency == @worst.central_tendency) || best.overlaps?(@worst)
       end
 
       def slowdown
         return @slowdown if @slowdown
-        @slowdown, @diff_error = stats.slowdown(baseline)
+        @slowdown, @diff_error = stats.slowdown(best)
         @slowdown
       end
 
@@ -98,7 +105,7 @@ module Benchmark
       end
 
       def comp_bar(width: 20, color: false)
-        fill = (baseline && !overlaps?) ? (width.to_f / slowdown).round : width
+        fill = (best && !overlaps?) ? (width.to_f / slowdown).round : width
         fill = fill.clamp(0, width)
         shade = width - fill
         bar = "█" * fill + "░" * shade
@@ -106,7 +113,7 @@ module Benchmark
       end
 
       def color
-        if !baseline
+        if !best
           ";0"
         elsif best? || overlaps?
           "32"

--- a/lib/benchmark/sweet/html_report.rb
+++ b/lib/benchmark/sweet/html_report.rb
@@ -3,7 +3,7 @@
 module Benchmark
   module Sweet
     class HtmlReport
-      attr_accessor :grouping, :row, :column, :sort, :value, :title
+      attr_accessor :grouping, :row, :column, :sort, :value, :title, :cell
 
       def initialize
         @grouping = nil
@@ -12,12 +12,13 @@ module Benchmark
         @sort = false
         @value = method(:render_cell)
         @title = "Benchmark Report"
+        @cell = nil
       end
 
       def render(comparisons, io)
         tables_html = []
 
-        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, value: -> c { c }, sort: sort) do |header_value, table_rows|
+        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, cell: cell, value: -> c { c }, sort: sort) do |header_value, table_rows|
           next if table_rows.empty?
           tables_html << render_table(header_value, table_rows)
         end
@@ -49,6 +50,8 @@ module Benchmark
               html << "        <td class=\"row-label\">#{escape(val.to_s)}</td>\n"
             elsif val.nil?
               html << "        <td></td>\n"
+            elsif val.is_a?(Hash)
+              html << val.values.map { |v| value.call(v, color: use_color) }.join
             elsif val.is_a?(Benchmark::Sweet::Comparison)
               html << value.call(val, color: use_color)
             else

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -283,6 +283,9 @@ module Benchmark
         formatter.column = @report_options[:column] if @report_options[:column]
         formatter.sort = @report_options[:sort] if @report_options[:sort]
         formatter.cell = @report_options[:cell] if @report_options[:cell] && formatter.respond_to?(:cell=)
+        formatter.bar = @report_options[:bar] if @report_options[:bar] && formatter.respond_to?(:bar=)
+        formatter.line = @report_options[:line] if @report_options[:line] && formatter.respond_to?(:line=)
+        formatter.scatter = @report_options[:scatter] if @report_options[:scatter] && formatter.respond_to?(:scatter=)
         formatter.value = @report_options[:value] if @report_options[:value]
         formatter.baseline = @report_options[:baseline] if @report_options[:baseline] && formatter.respond_to?(:baseline=)
         formatter.title = File.basename(@report_output.to_s, ".*") if @report_output && formatter.respond_to?(:title=)

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -123,6 +123,7 @@ module Benchmark
       #   x.compare_by :data
       #
       def compare_by(*symbol, &block)
+        @compare_by_keys = symbol unless symbol.empty?
         @grouping = symbol.empty? ? block : Proc.new { |label, _value| symbol.map { |s| label[s] } }
       end
 
@@ -233,6 +234,8 @@ module Benchmark
       end
 
       def run
+        return if items.empty?
+
         # run metrics if they are requested and haven't run yet
         # only run the suites that provide the data the user needs.
         # if the first node has the data, assumes all do
@@ -259,6 +262,7 @@ module Benchmark
         formatter.column = @report_options[:column] if @report_options[:column]
         formatter.sort = @report_options[:sort] if @report_options[:sort]
         formatter.value = @report_options[:value] if @report_options[:value]
+        formatter.baseline = @report_options[:baseline] if @report_options[:baseline] && formatter.respond_to?(:baseline=)
         formatter.title = File.basename(@report_output.to_s, ".*") if @report_output && formatter.respond_to?(:title=)
 
         io = case @report_output
@@ -274,8 +278,9 @@ module Benchmark
       # but then all data continues to the next step
       # this allows you to make comparisons across rows / columns / grouping
       def comparison_values
+        baseline_match = resolve_baseline(@report_options[:baseline])
+
         relevant_entries.flat_map do |metric_name, metric_entries|
-          # TODO: map these to Comparison(metric_name, label, stats) So we only have 1 type of lambda
           partitioned_metrics = grouping ? metric_entries.group_by(&grouping) : {nil => metric_entries}
           partitioned_metrics.flat_map do |_grouping_name, grouped_metrics|
             sorted = grouped_metrics.sort_by { |_n, e| e.central_tendency }
@@ -285,8 +290,12 @@ module Benchmark
             _worst_label, worst_stats = sorted.last
             total = sorted.count
 
-            # TODO: fix ranking. i / total doesn't work as well when there is only 1 entry or some entries are the same
-            comparisons = sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst_stats) }
+            reference_stats = if baseline_match
+              _label, stats = grouped_metrics.find { |label, _| baseline_match.all? { |k, v| label[k].to_s == v.to_s } }
+              stats
+            end
+
+            comparisons = sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst: worst_stats, reference: reference_stats) }
             @skip_unremarkable && comparisons.first&.all_same? ? [] : comparisons
           end
         end
@@ -294,11 +303,36 @@ module Benchmark
 
       private
 
+      # Resolve baseline to a label match hash.
+      # Hash: use as-is. String: derive the key from column/row vs compare_by.
+      # The baseline key is whichever of column/row is NOT in compare_by
+      # (i.e., the dimension that varies within a comparison group).
+      def resolve_baseline(baseline)
+        return baseline if baseline.is_a?(Hash)
+        return unless baseline
+
+        key = if @compare_by_keys
+          column = @report_options[:column]
+          row = @report_options[:row]
+          if column && !@compare_by_keys.include?(column)
+            column
+          elsif row && !@compare_by_keys.include?(row)
+            row
+          end
+        end
+        key ||= @report_options[:column]
+
+        key ? {key => baseline} : nil
+      end
+
       def resolve_formatter
         case @format
         when :html
           require "benchmark/sweet/html_report"
           Benchmark::Sweet::HtmlReport.new
+        when :chart
+          require "benchmark/sweet/chart_report"
+          Benchmark::Sweet::ChartReport.new
         when :markdown
           require "benchmark/sweet/markdown_report"
           Benchmark::Sweet::MarkdownReport.new

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -282,6 +282,7 @@ module Benchmark
         formatter.row = @report_options[:row] if @report_options[:row]
         formatter.column = @report_options[:column] if @report_options[:column]
         formatter.sort = @report_options[:sort] if @report_options[:sort]
+        formatter.cell = @report_options[:cell] if @report_options[:cell] && formatter.respond_to?(:cell=)
         formatter.value = @report_options[:value] if @report_options[:value]
         formatter.baseline = @report_options[:baseline] if @report_options[:baseline] && formatter.respond_to?(:baseline=)
         formatter.title = File.basename(@report_output.to_s, ".*") if @report_output && formatter.respond_to?(:title=)

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -159,8 +159,29 @@ module Benchmark
         @entries.dig(metric, label)
       end
 
+      # Filter entries by label values for reporting. Does not modify stored data.
+      # Hash: inclusion filter. Block: custom predicate on label.
+      # Examples:
+      #   filter config: %w[mp1 mp3 ltree]
+      #   filter { |label| !label[:operation].start_with?("ancestor_ids") }
+      #   filter(config: %w[mp1 mp3]) { |label| label[:operation] != "ancestor_ids cached" }
+      def filter(criteria = nil, &block)
+        @filter_criteria = criteria
+        @filter_block = block
+      end
+
       def relevant_entries
-        relevant_metric_names.map { |n| [n, @entries[n] ] }
+        entries = relevant_metric_names.map { |n| [n, @entries[n]] }
+        return entries unless @filter_criteria || @filter_block
+
+        entries.map do |metric_name, metric_entries|
+          filtered = metric_entries.select do |label, _stat|
+            next false if @filter_criteria && !@filter_criteria.all? { |k, v| Array(v).include?(label[k].to_s) }
+            next false if @filter_block && !@filter_block.call(label)
+            true
+          end
+          [metric_name, filtered]
+        end
       end
       # serialization
 

--- a/lib/benchmark/sweet/markdown_report.rb
+++ b/lib/benchmark/sweet/markdown_report.rb
@@ -3,7 +3,7 @@
 module Benchmark
   module Sweet
     class MarkdownReport
-      attr_accessor :grouping, :row, :column, :sort, :value
+      attr_accessor :grouping, :row, :column, :sort, :value, :cell
 
       def initialize
         @grouping = nil
@@ -11,10 +11,11 @@ module Benchmark
         @column = :metric
         @sort = false
         @value = method(:render_cell)
+        @cell = nil
       end
 
       def render(comparisons, io)
-        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, value: -> c { c }, sort: sort) do |header_value, table_rows|
+        Benchmark::Sweet.table(comparisons, grouping: grouping, row: row, column: column, cell: cell, value: -> c { c }, sort: sort) do |header_value, table_rows|
           next if table_rows.empty?
           print_table(header_value, table_rows, out: io)
         end
@@ -32,6 +33,8 @@ module Benchmark
             val = row_data[key]
             if val.nil?
               ""
+            elsif val.is_a?(Hash)
+              val.values.map { |v| value.call(v, color: false) }.join(" | ")
             elsif val.is_a?(Benchmark::Sweet::Comparison)
               value.call(val, color: false)
             else

--- a/spec/benchmark/comparison_edge_spec.rb
+++ b/spec/benchmark/comparison_edge_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Benchmark::Sweet::Comparison do
     Benchmark::IPS::Stats::SD.new(Array(values))
   end
 
-  def make_comparison(metric, label, stats, offset, total, baseline, worst = nil)
-    described_class.new(metric, label, stats, offset, total, baseline, worst)
+  def make_comparison(metric, label, stats, offset, total, best, worst: nil)
+    described_class.new(metric, label, stats, offset, total, best, worst: worst)
   end
 
   describe "#overlaps?" do
@@ -43,16 +43,16 @@ RSpec.describe Benchmark::Sweet::Comparison do
       fast = make_stats([100.0, 102.0, 101.0, 100.5, 101.5])
       mid  = make_stats([50.0, 52.0, 51.0, 50.5, 51.5])
       slow = make_stats([10.0, 12.0, 11.0, 10.5, 11.5])
-      comp = make_comparison("ips", {}, mid, 1, 3, fast, slow)
+      comp = make_comparison("ips", {}, mid, 1, 3, fast, worst: slow)
       expect(comp.worst?).to be false
-      comp2 = make_comparison("ips", {}, slow, 2, 3, fast, slow)
+      comp2 = make_comparison("ips", {}, slow, 2, 3, fast, worst: slow)
       expect(comp2.worst?).to be true
     end
 
     it "returns false when overlapping with best" do
       stats_a = make_stats([100.0, 102.0, 101.0])
       stats_b = make_stats([99.0, 101.0, 100.0])
-      comp = make_comparison("ips", {}, stats_b, 1, 2, stats_a, stats_b)
+      comp = make_comparison("ips", {}, stats_b, 1, 2, stats_a, worst: stats_b)
       expect(comp.worst?).to be false
     end
   end
@@ -61,28 +61,28 @@ RSpec.describe Benchmark::Sweet::Comparison do
     it "returns true when best and worst overlap" do
       stats_a = make_stats([100.0, 102.0, 101.0])
       stats_b = make_stats([99.0, 101.0, 100.0])
-      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
+      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, worst: stats_b)
       expect(comp.all_same?).to be true
     end
 
     it "returns true when best and worst have identical single samples" do
       stats_a = make_stats([1.0])
       stats_b = make_stats([1.0])
-      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, stats_b)
+      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, worst: stats_b)
       expect(comp.all_same?).to be true
     end
 
     it "returns false when best and worst are distinct" do
       fast = make_stats([100.0, 110.0, 105.0])
       slow = make_stats([10.0, 11.0, 10.5])
-      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
+      comp = make_comparison("ips", {}, fast, 0, 2, fast, worst: slow)
       expect(comp.all_same?).to be false
     end
 
     it "returns false when single samples differ" do
       stats_a = make_stats([1.0])
       stats_b = make_stats([2.0])
-      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, stats_b)
+      comp = make_comparison("queries", {}, stats_a, 0, 2, stats_a, worst: stats_b)
       expect(comp.all_same?).to be false
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Benchmark::Sweet::Comparison do
     it "returns false when all entries overlap" do
       stats_a = make_stats([100.0, 102.0, 101.0])
       stats_b = make_stats([99.0, 101.0, 100.0])
-      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, stats_b)
+      comp = make_comparison("ips", {}, stats_a, 0, 2, stats_a, worst: stats_b)
       expect(comp.best?).to be false
       expect(comp.mode).to eq(:same)
     end
@@ -105,7 +105,7 @@ RSpec.describe Benchmark::Sweet::Comparison do
     it "returns true when entries are distinct" do
       fast = make_stats([100.0, 110.0, 105.0])
       slow = make_stats([10.0, 11.0, 10.5])
-      comp = make_comparison("ips", {}, fast, 0, 2, fast, slow)
+      comp = make_comparison("ips", {}, fast, 0, 2, fast, worst: slow)
       expect(comp.best?).to be true
       expect(comp.mode).to eq(:best)
     end

--- a/spec/benchmark/comparison_spec.rb
+++ b/spec/benchmark/comparison_spec.rb
@@ -84,8 +84,13 @@ RSpec.describe Benchmark::Sweet::Comparison do
       expect(comp.units).to eq("bytes")
     end
 
-    it "returns objs for unknown metrics" do
+    it "returns queries for queries metric" do
       comp = make_comparison("queries", {}, fast_stats, 0, 1, fast_stats)
+      expect(comp.units).to eq("queries")
+    end
+
+    it "returns objs for unknown metrics" do
+      comp = make_comparison("unknown_metric", {}, fast_stats, 0, 1, fast_stats)
       expect(comp.units).to eq("objs")
     end
   end

--- a/spec/benchmark/comparison_spec.rb
+++ b/spec/benchmark/comparison_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Benchmark::Sweet::Comparison do
     Benchmark::IPS::Stats::SD.new(Array(values))
   end
 
-  def make_comparison(metric, label, stats, offset, total, baseline, worst = nil)
-    Benchmark::Sweet::Comparison.new(metric, label, stats, offset, total, baseline, worst)
+  def make_comparison(metric, label, stats, offset, total, best, worst: nil)
+    Benchmark::Sweet::Comparison.new(metric, label, stats, offset, total, best, worst: worst)
   end
 
   let(:fast_stats) { make_stats([100.0, 110.0, 105.0]) }
@@ -39,6 +39,37 @@ RSpec.describe Benchmark::Sweet::Comparison do
     it "returns a factor > 1 for slower entries" do
       comp = make_comparison("ips", {method: "slow"}, slow_stats, 1, 2, fast_stats)
       expect(comp.slowdown).to be > 1.0
+    end
+  end
+
+  describe "#ratio" do
+    # fast ~105, slow ~52, so mid between them
+    let(:mid_stats) { make_stats([75.0, 77.0, 76.0]) }
+
+    it "returns nil when no reference is set" do
+      comp = make_comparison("ips", {method: "fast"}, fast_stats, 0, 2, fast_stats)
+      expect(comp.ratio).to be_nil
+    end
+
+    it "returns 1.0 for the reference entry itself" do
+      comp = Benchmark::Sweet::Comparison.new("ips", {method: "mid"}, mid_stats, 1, 3, fast_stats, worst: slow_stats, reference: mid_stats)
+      expect(comp.ratio).to eq(1.0)
+    end
+
+    it "returns >1.0 when faster than reference" do
+      comp = Benchmark::Sweet::Comparison.new("ips", {method: "fast"}, fast_stats, 0, 3, fast_stats, worst: slow_stats, reference: mid_stats)
+      expect(comp.ratio).to be > 1.0
+    end
+
+    it "returns <1.0 when slower than reference" do
+      comp = Benchmark::Sweet::Comparison.new("ips", {method: "slow"}, slow_stats, 2, 3, fast_stats, worst: slow_stats, reference: mid_stats)
+      expect(comp.ratio).to be < 1.0
+    end
+
+    it "preserves best/worst ranking independent of reference" do
+      comp = Benchmark::Sweet::Comparison.new("ips", {method: "fast"}, fast_stats, 0, 3, fast_stats, worst: slow_stats, reference: mid_stats)
+      expect(comp.best?).to be true
+      expect(comp.ratio).to be > 1.0
     end
   end
 

--- a/spec/benchmark/comparison_spec.rb
+++ b/spec/benchmark/comparison_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Benchmark::Sweet::Comparison do
       expect(comp.ratio).to be < 1.0
     end
 
+    it "returns nil when reference has zero central_tendency" do
+      zero_stats = make_stats([0.0])
+      comp = Benchmark::Sweet::Comparison.new("queries", {method: "fast"}, fast_stats, 0, 2, fast_stats, reference: zero_stats)
+      expect(comp.ratio).to be_nil
+    end
+
     it "preserves best/worst ranking independent of reference" do
       comp = Benchmark::Sweet::Comparison.new("ips", {method: "fast"}, fast_stats, 0, 3, fast_stats, worst: slow_stats, reference: mid_stats)
       expect(comp.best?).to be true

--- a/spec/benchmark/grouping_spec.rb
+++ b/spec/benchmark/grouping_spec.rb
@@ -114,5 +114,38 @@ RSpec.describe Benchmark::Sweet do
       end
       expect(headers).to contain_exactly("wide", "deep")
     end
+
+    it "collects into hash when cell is set" do
+      comps = [
+        make_comparison("ips", {method: "fast", config: "mp1"}, stats_fast),
+        make_comparison("queries", {method: "fast", config: "mp1"}, make_stats([1.0])),
+        make_comparison("ips", {method: "fast", config: "mp3"}, stats_slow),
+        make_comparison("queries", {method: "fast", config: "mp3"}, make_stats([2.0])),
+      ]
+
+      rows = nil
+      described_class.table(comps, row: :method, column: :config, cell: :metric) do |_, r|
+        rows = r
+      end
+      expect(rows.length).to eq(1)
+      cell = rows.first["mp1"]
+      expect(cell).to be_a(Hash)
+      expect(cell.keys).to contain_exactly("ips", "queries")
+      expect(cell["ips"]).to be_a(Benchmark::Sweet::Comparison)
+    end
+
+    it "returns single value without cell (backwards compatible)" do
+      comps = [
+        make_comparison("ips", {method: "fast", config: "mp1"}, stats_fast),
+      ]
+
+      rows = nil
+      described_class.table(comps, row: :method, column: :config, value: -> c { c }) do |_, r|
+        rows = r
+      end
+      cell = rows.first["mp1"]
+      expect(cell).to be_a(Benchmark::Sweet::Comparison)
+      expect(cell).not_to be_a(Hash)
+    end
   end
 end

--- a/spec/benchmark/grouping_spec.rb
+++ b/spec/benchmark/grouping_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Benchmark::Sweet do
     Benchmark::IPS::Stats::SD.new(Array(values))
   end
 
-  def make_comparison(metric, label, stats, offset = 0, total = 1, baseline = stats)
-    Benchmark::Sweet::Comparison.new(metric, label, stats, offset, total, baseline)
+  def make_comparison(metric, label, stats, offset = 0, total = 1, best = stats)
+    Benchmark::Sweet::Comparison.new(metric, label, stats, offset, total, best)
   end
 
   describe ".symbol_to_proc" do

--- a/spec/benchmark/job_spec.rb
+++ b/spec/benchmark/job_spec.rb
@@ -201,6 +201,58 @@ RSpec.describe Benchmark::Sweet::Job do
     end
   end
 
+  describe "#filter" do
+    it "filters by hash inclusion" do
+      job = described_class.new(metrics: %w(ips))
+      job.add_entry({config: "mp1", operation: "fast"}, "ips", [100.0])
+      job.add_entry({config: "mp3", operation: "fast"}, "ips", [200.0])
+      job.add_entry({config: "ltree", operation: "fast"}, "ips", [150.0])
+
+      job.filter config: %w[mp1 mp3]
+      entries = job.relevant_entries
+      labels = entries.flat_map { |_, h| h.keys.map { |l| l[:config] } }
+      expect(labels).to contain_exactly("mp1", "mp3")
+    end
+
+    it "filters by block" do
+      job = described_class.new(metrics: %w(ips))
+      job.add_entry({config: "mp1", operation: "fast"}, "ips", [100.0])
+      job.add_entry({config: "mp1", operation: "slow"}, "ips", [10.0])
+
+      job.filter { |label| label[:operation] != "slow" }
+      entries = job.relevant_entries
+      labels = entries.flat_map { |_, h| h.keys.map { |l| l[:operation] } }
+      expect(labels).to eq(["fast"])
+    end
+
+    it "combines hash and block" do
+      job = described_class.new(metrics: %w(ips))
+      job.add_entry({config: "mp1", operation: "fast"}, "ips", [100.0])
+      job.add_entry({config: "mp1", operation: "slow"}, "ips", [10.0])
+      job.add_entry({config: "mp3", operation: "fast"}, "ips", [200.0])
+
+      job.filter(config: %w[mp1]) { |label| label[:operation] == "fast" }
+      entries = job.relevant_entries
+      labels = entries.flat_map { |_, h| h.keys }
+      expect(labels.length).to eq(1)
+      expect(labels.first[:config]).to eq("mp1")
+      expect(labels.first[:operation]).to eq("fast")
+    end
+
+    it "does not affect save_entries" do
+      Tempfile.create(["benchmark", ".json"]) do |f|
+        job = described_class.new(metrics: %w(ips))
+        job.add_entry({config: "mp1"}, "ips", [100.0])
+        job.add_entry({config: "mp3"}, "ips", [200.0])
+        job.filter config: %w[mp1]
+        job.save_entries(f.path)
+
+        saved = JSON.parse(File.read(f.path))
+        expect(saved.length).to eq(2)
+      end
+    end
+  end
+
   describe "serialization" do
     it "round-trips entries through save and load" do
       Tempfile.create(["benchmark", ".json"]) do |f|


### PR DESCRIPTION
- rename `baseline` to `best` so it is easier to compare from baseline to other entries.
- add reference-based `ratio` for number of times faster.
- Add ChartReport (uses `Chart.js` bar and line charts)
- Add `filter` to reduce what gets into the report
- Add metric units for more tests.
- add `cell` that allows multiple metrics into a single cell.
