### PR TITLE
Keep entries when there is only one entry in a comparison group

### DIFF
--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -73,6 +73,19 @@ module Benchmark
       end
     end
 
+    # Extract sorted column headers from table rows.
+    # Row label key stays first, remaining columns sorted alphabetically.
+    # If baseline is provided, it comes immediately after the row label.
+    def self.column_headers(table_rows, baseline: nil)
+      headers = table_rows.flat_map(&:keys).uniq
+      row_key = headers.first
+      columns = headers[1..].sort_by(&:to_s)
+      if baseline && (idx = columns.index { |c| c.to_s == baseline.to_s })
+        columns.unshift(columns.delete_at(idx))
+      end
+      [row_key, *columns]
+    end
+
     # proc produced: -> (comparison) { comparison.method }
     def self.symbol_to_proc(field, join: "_")
       if field.kind_of?(Symbol) || field.kind_of?(String)

--- a/lib/benchmark/sweet/chart_report.rb
+++ b/lib/benchmark/sweet/chart_report.rb
@@ -39,7 +39,7 @@ module Benchmark
       private
 
       def build_chart_data(header_value, table_rows)
-        headers = table_rows.flat_map(&:keys).uniq
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
         row_key = headers.first
         column_keys = headers[1..]
 
@@ -74,7 +74,7 @@ module Benchmark
       # Build chart when cell: :metric is set. Each cell is a hash of {metric => Comparison}.
       # bar/line attrs control which metric renders as which type.
       def build_multi_metric_chart(header_value, table_rows)
-        headers = table_rows.flat_map(&:keys).uniq
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
         row_key = headers.first
         column_keys = headers[1..]
 

--- a/lib/benchmark/sweet/html_report.rb
+++ b/lib/benchmark/sweet/html_report.rb
@@ -32,7 +32,7 @@ module Benchmark
         html = ""
         html << "    <h2>#{escape(header_value.to_s)}</h2>\n" if header_value
 
-        headers = table_rows.flat_map(&:keys).uniq
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
         # With 2 data columns, every cell is best or worst — color is noise, just bold best.
         # With 3+, color helps scan for the best/worst across many options.
         use_color = headers.size > 3

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -321,7 +321,7 @@ module Benchmark
             end
 
             comparisons = sorted.each_with_index.map { |(label, stats), i| Comparison.new(metric_name, label, stats, i, total, best_stats, worst: worst_stats, reference: reference_stats) }
-            @skip_unremarkable && comparisons.first&.all_same? ? [] : comparisons
+            @skip_unremarkable && comparisons.size > 1 && comparisons.first&.all_same? ? [] : comparisons
           end
         end
       end

--- a/lib/benchmark/sweet/markdown_report.rb
+++ b/lib/benchmark/sweet/markdown_report.rb
@@ -26,7 +26,7 @@ module Benchmark
       def print_table(header_value, table_rows, out: $stdout)
         return if table_rows.empty?
 
-        headers = table_rows.flat_map(&:keys).uniq
+        headers = Benchmark::Sweet.column_headers(table_rows)
 
         formatted_rows = table_rows.map do |row_data|
           headers.map do |key|

--- a/spec/benchmark/job_spec.rb
+++ b/spec/benchmark/job_spec.rb
@@ -191,6 +191,15 @@ RSpec.describe Benchmark::Sweet::Job do
       expect(comparisons.map { |c| c[:operation] }.uniq).to eq(["descendants"])
     end
 
+    it "keeps single entry even when all_same would be true" do
+      job = described_class.new(metrics: %w(queries))
+      job.add_entry({operation: "parent"}, "queries", [1.0])
+      job.skip_unremarkable!
+
+      comparisons = job.comparison_values
+      expect(comparisons.length).to eq(1)
+    end
+
     it "does not filter when not enabled" do
       job = described_class.new(metrics: %w(queries))
       job.add_entry({operation: "parent"}, "queries", [1.0])


### PR DESCRIPTION
Motivation
---

`skip_unremarkable!` removes comparison groups where all entries overlap.
With a single entry, `all_same?` compares best vs worst, which is the same
object, so it always returns true. This removes the only entry.

Before / After
---

Before: single-entry groups are removed by `skip_unremarkable!`
After: single-entry groups are kept (need at least 2 entries to compare)