### PR TITLE
HtmlReport: baseline raw values, ratio display, neutral colors

### DIFF
--- a/lib/benchmark/sweet/comparison.rb
+++ b/lib/benchmark/sweet/comparison.rb
@@ -15,6 +15,10 @@ module Benchmark
         @reference = reference
       end
 
+      def baseline?
+        @reference && stats.equal?(@reference)
+      end
+
       # Value relative to a named baseline. >1.0 = faster/better, <1.0 = slower/worse.
       def ratio
         return nil unless @reference

--- a/lib/benchmark/sweet/html_report.rb
+++ b/lib/benchmark/sweet/html_report.rb
@@ -68,9 +68,11 @@ module Benchmark
       end
 
       def render_cell(c, color: true)
-        ratio = c.ratio
-        if ratio
-          val = ratio == 1.0 ? "1x" : "%.1fx" % ratio
+        if c.baseline?
+          val = format_number(c.central_tendency)
+          tip = escape("baseline (#{c.units})")
+        elsif c.ratio
+          val = "%.1fx" % c.ratio
           tip = escape("#{format_number(c.central_tendency)} #{c.units}")
         else
           val = format_number(c.central_tendency)
@@ -87,7 +89,7 @@ module Benchmark
       def css_color(comparison)
         case comparison.mode
         when :best then "#1a7f37"
-        when :same then "#1a7f37"
+        when :same then "#656d76"
         when :slower then comparison.worst? ? "#cf222e" : "#656d76"
         when :slowerish then "#656d76"
         end


### PR DESCRIPTION
Motivation
---

HTML tables showed raw i/s for every cell, making it hard to scan for
meaningful differences. "Same" entries were colored green like "best",
so color didn't help either.

Before
---

All cells show raw i/s (e.g. "9,686"). Same-as-best cells colored green.
No visual distinction between baseline and other entries.

After
---

Baseline cell shows raw i/s to anchor the reader to actual scale. Other
cells show ratio ("1.1x") with raw i/s in tooltip. Only best (green)
and worst (red) get color. Everything in between is neutral gray.

Adds `Comparison#baseline?` using object identity to distinguish the
actual baseline from entries that happen to match its value.

Only activates when a baseline is configured. The `value` accessor
allows full override via `report_with value: ->(c, color:) { ... }`.

Also fixes `FrozenError` in `render_table` for frozen_string_literal.