### PR TITLE
Add column_sort option for custom column ordering

### DIFF
--- a/lib/benchmark/sweet.rb
+++ b/lib/benchmark/sweet.rb
@@ -73,15 +73,21 @@ module Benchmark
       end
     end
 
-    # Extract sorted column headers from table rows.
-    # Row label key stays first, remaining columns sorted alphabetically.
-    # If baseline is provided, it comes immediately after the row label.
-    def self.column_headers(table_rows, baseline: nil)
+    # Extract column headers from table rows. Row label key stays first.
+    # @param column_sort [Boolean, Proc] false for insertion order, true for alphabetical,
+    #   or a lambda receiving column array returning ordered array.
+    # @param baseline [String, nil] pinned first (after row label) for boolean column_sort.
+    def self.column_headers(table_rows, baseline: nil, column_sort: false)
       headers = table_rows.flat_map(&:keys).uniq
       row_key = headers.first
-      columns = headers[1..].sort_by(&:to_s)
-      if baseline && (idx = columns.index { |c| c.to_s == baseline.to_s })
-        columns.unshift(columns.delete_at(idx))
+      columns = headers[1..]
+      if column_sort.respond_to?(:call)
+        columns = column_sort.call(columns)
+      elsif column_sort
+        columns = columns.sort_by(&:to_s)
+        if baseline && (idx = columns.index { |c| c.to_s == baseline.to_s })
+          columns.unshift(columns.delete_at(idx))
+        end
       end
       [row_key, *columns]
     end

--- a/lib/benchmark/sweet/chart_report.rb
+++ b/lib/benchmark/sweet/chart_report.rb
@@ -3,7 +3,7 @@
 module Benchmark
   module Sweet
     class ChartReport
-      attr_accessor :grouping, :row, :column, :sort, :value, :title, :baseline, :cell
+      attr_accessor :grouping, :row, :column, :sort, :column_sort, :value, :title, :baseline, :cell
       # bar/line/scatter: metric names (Symbol or Array) for chart type mapping
       attr_accessor :bar, :line, :scatter
 
@@ -39,7 +39,7 @@ module Benchmark
       private
 
       def build_chart_data(header_value, table_rows)
-        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline, column_sort: @column_sort)
         row_key = headers.first
         column_keys = headers[1..]
 
@@ -74,7 +74,7 @@ module Benchmark
       # Build chart when cell: :metric is set. Each cell is a hash of {metric => Comparison}.
       # bar/line attrs control which metric renders as which type.
       def build_multi_metric_chart(header_value, table_rows)
-        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline, column_sort: @column_sort)
         row_key = headers.first
         column_keys = headers[1..]
 

--- a/lib/benchmark/sweet/html_report.rb
+++ b/lib/benchmark/sweet/html_report.rb
@@ -3,7 +3,7 @@
 module Benchmark
   module Sweet
     class HtmlReport
-      attr_accessor :grouping, :row, :column, :sort, :value, :title, :cell, :baseline
+      attr_accessor :grouping, :row, :column, :sort, :column_sort, :value, :title, :cell, :baseline
 
       def initialize
         @grouping = nil
@@ -33,7 +33,7 @@ module Benchmark
         html = +""
         html << "    <h2>#{escape(header_value.to_s)}</h2>\n" if header_value
 
-        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline)
+        headers = Benchmark::Sweet.column_headers(table_rows, baseline: @baseline, column_sort: @column_sort)
         # With 2 data columns, every cell is best or worst — color is noise, just bold best.
         # With 3+, color helps scan for the best/worst across many options.
         use_color = headers.size > 3

--- a/lib/benchmark/sweet/job.rb
+++ b/lib/benchmark/sweet/job.rb
@@ -282,6 +282,7 @@ module Benchmark
         formatter.row = @report_options[:row] if @report_options[:row]
         formatter.column = @report_options[:column] if @report_options[:column]
         formatter.sort = @report_options[:sort] if @report_options[:sort]
+        formatter.column_sort = @report_options[:column_sort] if @report_options.key?(:column_sort) && formatter.respond_to?(:column_sort=)
         formatter.cell = @report_options[:cell] if @report_options[:cell] && formatter.respond_to?(:cell=)
         formatter.bar = @report_options[:bar] if @report_options[:bar] && formatter.respond_to?(:bar=)
         formatter.line = @report_options[:line] if @report_options[:line] && formatter.respond_to?(:line=)

--- a/lib/benchmark/sweet/markdown_report.rb
+++ b/lib/benchmark/sweet/markdown_report.rb
@@ -3,7 +3,7 @@
 module Benchmark
   module Sweet
     class MarkdownReport
-      attr_accessor :grouping, :row, :column, :sort, :value, :cell
+      attr_accessor :grouping, :row, :column, :sort, :column_sort, :value, :cell
 
       def initialize
         @grouping = nil
@@ -26,7 +26,7 @@ module Benchmark
       def print_table(header_value, table_rows, out: $stdout)
         return if table_rows.empty?
 
-        headers = Benchmark::Sweet.column_headers(table_rows)
+        headers = Benchmark::Sweet.column_headers(table_rows, column_sort: @column_sort)
 
         formatted_rows = table_rows.map do |row_data|
           headers.map do |key|


### PR DESCRIPTION
Parallels the existing `sort` option (which controls row ordering).
Accepts `false` (insertion order, default), `true` (alphabetical),
or a lambda for custom ordering.

Motivation
---
Version comparison tables need chronological ordering with `master` pinned last.
Previously columns were always alphabetical with no override.

Before
---
Columns always sorted alphabetically. No way to control order.

After
---
`report_with column_sort: true` for alphabetical (preserves current behavior).
`report_with column_sort: -> cols { ... }` for custom ordering.
When a lambda is provided, baseline pinning is the caller's responsibility.